### PR TITLE
Navbar - Signed in status and Links

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -9,7 +9,7 @@
 
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto d-flex align-items-center">
-      <% if true # user_signed_in? %>
+      <% if user_signed_in? %>
         <li class="nav-item active">
           <a class="nav-link" href="#">Rent your star</a>
         </li>      
@@ -19,7 +19,11 @@
             <a class="dropdown-item" href="#">My bookings</a>
             <a class="dropdown-item" href="#">My listings</a>
             <a class="dropdown-item" href="#">My profile</a>
-            <a class="dropdown-item" href="#">Sign out</a>
+            <%= link_to "Sign out",
+                        destroy_user_session_path(@session),
+                        method: :delete,
+                        data: { confirm: "Are you sure you want to logout ?" },
+                        class: "dropdown-item" %>
           </div>
         </li>
       <% else %>
@@ -27,7 +31,7 @@
           <a class="nav-link" href="#">Rent your star</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="#">Sign in</a>
+          <a class="nav-link" href="/users/sign_in">Sign in</a>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
- Use the user_signed_in? helper to discriminate between logged in and not logged in users
- Enable the Sign out link for signed in users -> destroy the current session
- Enable the Sign in link for not signed in users -> redirect to /users/sign_in
On branch navbar-redirect-to-sign-in
Changes to be committed:
modified:   app/views/shared/_navbar.html.erb